### PR TITLE
Use stdin instead of arguments for cli.js inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sh make.sh -d
 To normalise bob.elm and save results to bob-normalized.elm
 
 ```bash
-node src/cli.js "$(cat bob.elm)" > bob-normalized.elm
+cat bob.elm | node src/cli.js > bob-normalized.elm
 ```
 
 To normalize all the example files in this repo

--- a/normalize-examples.sh
+++ b/normalize-examples.sh
@@ -1,12 +1,12 @@
 sh make.sh
 
-node src/cli.js "$(cat example-originals/Anagram.elm)" > examples-normalized/Anagram.elm
-node src/cli.js "$(cat example-originals/Bob.elm)" > examples-normalized/Bob.elm
-node src/cli.js "$(cat example-originals/GradeSchool.elm)" > examples-normalized/GradeSchool.elm
-node src/cli.js "$(cat example-originals/Hamming.elm)" > examples-normalized/Hamming.elm
-node src/cli.js "$(cat example-originals/Leap.elm)" > examples-normalized/Leap.elm
-node src/cli.js "$(cat example-originals/Pangram.elm)" > examples-normalized/Pangram.elm
-node src/cli.js "$(cat example-originals/Raindrops.elm)" > examples-normalized/Raindrops.elm
-node src/cli.js "$(cat example-originals/SumOfMultiples.elm)" > examples-normalized/SumOfMultiples.elm
-node src/cli.js "$(cat example-originals/Triangle.elm)" > examples-normalized/Triangle.elm
-node src/cli.js "$(cat example-originals/TwelveDays.elm)" > examples-normalized/TwelveDays.elm
+cat example-originals/Anagram.elm        | node src/cli.js > examples-normalized/Anagram.elm
+cat example-originals/Bob.elm            | node src/cli.js > examples-normalized/Bob.elm
+cat example-originals/GradeSchool.elm    | node src/cli.js > examples-normalized/GradeSchool.elm
+cat example-originals/Hamming.elm        | node src/cli.js > examples-normalized/Hamming.elm
+cat example-originals/Leap.elm           | node src/cli.js > examples-normalized/Leap.elm
+cat example-originals/Pangram.elm        | node src/cli.js > examples-normalized/Pangram.elm
+cat example-originals/Raindrops.elm      | node src/cli.js > examples-normalized/Raindrops.elm
+cat example-originals/SumOfMultiples.elm | node src/cli.js > examples-normalized/SumOfMultiples.elm
+cat example-originals/Triangle.elm       | node src/cli.js > examples-normalized/Triangle.elm
+cat example-originals/TwelveDays.elm     | node src/cli.js > examples-normalized/TwelveDays.elm

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,9 +3,9 @@
 var Elm = require('./main').Elm;
 var main = Elm.Main.init();
 
-// Get data from the command line
-var args = process.argv.slice(2);
-var input = args[0]
+// Get data from stdin
+var fs = require("fs");
+var input = fs.readFileSync(process.stdin.fd, "utf-8");
 //console.log("\n   Input: ", input)
 
 // Send data to the worker


### PR DESCRIPTION
It feels cleaner to read from stdin than to use arguments for inputs. I also kind of remember that command line arguments can create issues if they get too long.